### PR TITLE
run inspectArgs on the object if format is not known

### DIFF
--- a/format.ts
+++ b/format.ts
@@ -337,7 +337,19 @@ export function format(obj: unknown): Displayable {
     });
   }
 
-  // TODO (rgbkrk): Create colored output like Deno execute_result has
+  // @ts-ignore: the Deno internal symbol is hidden
+  const internalSymbol = Deno.internal;
+
+  if (typeof internalSymbol === "symbol") {
+    // @ts-ignore: the internal API is hidden behind a symbol
+    const DenoInternal = Deno[internalSymbol];
+    return makeDisplayable({
+      "text/plain": DenoInternal.inspectArgs(["%o", obj], {
+        colors: !Deno.noColor,
+      }),
+    });
+  }
+
   return makeDisplayable({
     "text/plain": Deno.inspect(obj),
   });


### PR DESCRIPTION
This makes `display` consistent with result formatting for arbitrary objects.

<img width="253" alt="image" src="https://github.com/rgbkrk/display.js/assets/836375/0eccbe4c-f7a5-4e65-af09-3617062f584e">