### PR TITLE
Check for undefined explicitly in tagged template values

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -83,7 +83,8 @@ function hasJupyterBroadcast(d: typeof Deno): d is DenoJupyter {
 function createTaggedTemplate(mediatype: string) {
   return (strings: TemplateStringsArray, ...values: unknown[]) => {
     const payload = strings.reduce(
-      (acc, string, i) => acc + string + (values[i] || ""),
+      (acc, string, i) =>
+        acc + string + (values[i] !== undefined ? values[i] : ""),
       "",
     );
 


### PR DESCRIPTION
The tagged templates for `md`, `html`, etc. were turning `0` into `""` when they should just pass through the value directly.